### PR TITLE
fix: handle UTF-8 boundary in get_summary fallback path

### DIFF
--- a/src/markdown.rs
+++ b/src/markdown.rs
@@ -296,7 +296,12 @@ impl MarkdownContent {
             // Fallback: take first characters of content
             let content_text = self.extract_plain_text();
             if content_text.len() > max_length {
-                format!("{}...", &content_text[..max_length])
+                // Find the nearest valid UTF-8 boundary
+                let mut boundary = max_length;
+                while boundary > 0 && !content_text.is_char_boundary(boundary) {
+                    boundary -= 1;
+                }
+                format!("{}...", &content_text[..boundary])
             } else {
                 content_text
             }


### PR DESCRIPTION
When content_text contains multi-byte UTF-8 characters (e.g., Chinese), slicing at byte index max_length can land in the middle of a character, causing a panic. Find the nearest valid char boundary before slicing.

log

> thread 'main' (9) panicked at /Users/xxx/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/wechat-pub-rs-0.2.3/src/markdown.rs:170:52:
> byte index 120 is not a char boundary; it is inside '。' (bytes 119..122) of `最近这段时间我在尝试「vibe
> coding」——脑子里有想法就直接说出来，让电脑帮我落成文字。折腾了一圈之后，最顺手的一款工具，反而是一个很克制的小开源软件：Tok，一款基于本地 Whisper 的`[...]
> note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace